### PR TITLE
Fix bug when there is a special character on the path to the batch file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ default:
 %.qm : %.ts
 	$(LRELEASE) $<
 
-test: transcompile
+test:
 	@echo
 	@echo "----------------------"
 	@echo "Regression Test Suite"

--- a/processing_saga_nextgen/processing/utils.py
+++ b/processing_saga_nextgen/processing/utils.py
@@ -226,17 +226,18 @@ class SagaUtils:
         if ProcessingConfig.getSetting(SagaUtils.SAGA_LOG_CONSOLE):
             QgsMessageLog.logMessage('\n'.join(loglines), 'Processing', Qgis.Info)
 
+
 def makePathSafe(path):
     """Handle special characters on the path to the batch file for example: & < > ( ) @ ^ |.
     See: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd#remarks
     """
     return '"' + path.translate(str.maketrans({
-        "&":  r"^&",
-        "<":  r"^<",
-        ">":  r"^>",
-        "(":  r"^(",
-        ")":  r"^)",
-        "@":  r"^@",
-        "^":  r"^^",
-        "|":  r"^|",
+        "&": r"^&",
+        "<": r"^<",
+        ">": r"^>",
+        "(": r"^(",
+        ")": r"^)",
+        "@": r"^@",
+        "^": r"^^",
+        "|": r"^|",
     })) + '"'

--- a/processing_saga_nextgen/processing/utils.py
+++ b/processing_saga_nextgen/processing/utils.py
@@ -227,6 +227,9 @@ class SagaUtils:
             QgsMessageLog.logMessage('\n'.join(loglines), 'Processing', Qgis.Info)
 
 def makePathSafe(path):
+    """Handle special characters on the path to the batch file for example: & < > ( ) @ ^ |.
+    See: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd#remarks
+    """
     return '"' + path.translate(str.maketrans({
         "&":  r"^&",
         "<":  r"^<",

--- a/processing_saga_nextgen/processing/utils.py
+++ b/processing_saga_nextgen/processing/utils.py
@@ -188,7 +188,9 @@ class SagaUtils:
         """
 
         if isWindows():
-            command = ['cmd.exe', '/C ', SagaUtils.sagaBatchJobFilename()]
+            safeSagaBatchJobFilename = makePathSafe(SagaUtils.sagaBatchJobFilename())
+            command = ['cmd.exe', '/C ', safeSagaBatchJobFilename]
+            command = (' ').join(command)
         else:
             os.chmod(SagaUtils.sagaBatchJobFilename(), stat.S_IEXEC |
                      stat.S_IREAD | stat.S_IWRITE)
@@ -223,3 +225,15 @@ class SagaUtils:
 
         if ProcessingConfig.getSetting(SagaUtils.SAGA_LOG_CONSOLE):
             QgsMessageLog.logMessage('\n'.join(loglines), 'Processing', Qgis.Info)
+
+def makePathSafe(path):
+    return '"' + path.translate(str.maketrans({
+        "&":  r"^&",
+        "<":  r"^<",
+        ">":  r"^>",
+        "(":  r"^(",
+        ")":  r"^)",
+        "@":  r"^@",
+        "^":  r"^^",
+        "|":  r"^|",
+    })) + '"'

--- a/processing_saga_nextgen/test/test_utils.py
+++ b/processing_saga_nextgen/test/test_utils.py
@@ -1,0 +1,9 @@
+from ..processing.utils import makePathSafe
+from unittest import TestCase
+
+
+class UtilTests(TestCase):
+    def test_makePathSafe(self):
+        path = r"C:\Users\fclementi\AppData\Roaming\QGIS\QGIS3\profiles\new(profile)\processing\saga_batch_job.bat"
+        expected = r'"C:\Users\fclementi\AppData\Roaming\QGIS\QGIS3\profiles\new^(profile^)\processing\saga_batch_job.bat"'
+        assert expected == makePathSafe(path)


### PR DESCRIPTION
This PR fixes the bug when the batch file to run the SAGA command has a special character (fix #26). The reference to the special character: https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd#remarks

There are two situations that this can happen:
1. User creates a profile with a special character, e.g. `new(profile)`
2. There is already a special character on the QGIS profile directory's path, e.g. `D:\\Users\Company\UserName\AppData(Roaming)\QGIS\QGIS3\profiles\default\processing`

This PR fixes a real-world issue (situation 2 above). We can reproduce it by creating a profile with a special character (situation 1).