### PR TITLE
shapes_tools_shapes_buffer: make DIST_FIELD optional

### DIFF
--- a/processing_saga_nextgen/description/shapes_tools_shapes_buffer.txt
+++ b/processing_saga_nextgen/description/shapes_tools_shapes_buffer.txt
@@ -2,7 +2,7 @@ Shapes Buffer|18
 shapes_tools
 QgsProcessingParameterFeatureSource|SHAPES|Shapes|-1|None|False
 QgsProcessingParameterVectorDestination|BUFFER|Buffer|2|None|False
-QgsProcessingParameterField|DIST_FIELD|Buffer Distance|None|SHAPES|-1|False|False
+QgsProcessingParameterField|DIST_FIELD|Buffer Distance|None|SHAPES|-1|False|True
 QgsProcessingParameterNumber|DIST_FIELD_DEFAULT|Default|QgsProcessingParameterNumber.Double|100.000000|False|0.000000|None
 QgsProcessingParameterNumber|DIST_SCALE|Scaling Factor for Attribute Value|QgsProcessingParameterNumber.Double|1.000000|False|0.000000|None
 QgsProcessingParameterBoolean|DISSOLVE|Dissolve Buffers|True


### PR DESCRIPTION
Otherwise it is not possible to create a buffer with a fixed distance.